### PR TITLE
_model_xray NameError fix

### DIFF
--- a/ml_insights/insights.py
+++ b/ml_insights/insights.py
@@ -143,7 +143,7 @@ class ModelXRay(object):
             if type(self.data) == pd.DataFrame:
                 columns = self.data.columns
             else:
-                columns = range(len(data[0]))  # Assuming a 2-D Dataset
+                columns = range(len(self.data[0]))  # Assuming a 2-D Dataset
         else:
             # Verify that columns is an iterable
             try:


### PR DESCRIPTION
NameError raised if data is not a DataFrame due to reference to "data" in _model_xray