### PR TITLE
Remove numpy import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from setuptools import setup
-import numpy
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
The numpy import here causes error since, at build time, numpy is not available. It is also not used within the setup!

I needed this change in order to install your package with `poetry`.

N.B. The install still doesn't work since a dependency (splinecalib) does the same. To fix that, please may you add a pyproject.toml to let python know what numpy is needed to install the package? I've added a fix here: https://github.com/numeristical/splinecalib/pull/5